### PR TITLE
Issue 5: Limit message lengths to 4K (TCP), 1K (UDP). Refactor + unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "4.2"
+env:
+  - TESTCOMMAND=test
+script:
+  - npm $TESTCOMMAND 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test:unit",
+    "test:unit": "bash -c '(chmod u+x scripts/runUnitTests.sh; scripts/runUnitTests.sh)'"
   },
   "author": "",
   "license": "MIT",
   "private": false,
   "dependencies": {
     "log4js": "^0.6.33"
+  },
+  "devDependencies": {
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.3"
   }
 }

--- a/scripts/runUnitTests.sh
+++ b/scripts/runUnitTests.sh
@@ -1,0 +1,32 @@
+# See bash(1)
+set -o pipefail
+
+SUBFOLDERS=( "unit" )
+
+# Track whether there has been a test failure.  Should only
+# be set to the word "true" or the word "false".
+#
+isTestRunSuccessful=true
+
+for SUBFOLDER in "${SUBFOLDERS[@]}"
+do
+  for file in tests/$SUBFOLDER/*.js
+  do   
+    filename="${file##*/}"
+    echo "$file:"
+    [ -f "$file" ] && node_modules/.bin/tape "${file}" | node_modules/.bin/tap-spec 
+    if [ $? -ne 0 ] ; then
+      isTestRunSuccessful=false
+    fi
+  done
+done
+
+# It is important that this is either set to the word true
+# or the word false.
+#
+if $isTestRunSuccessful; then
+  exit 0
+else
+  echo "One or more tests failed. Failing suite."
+  exit 1
+fi

--- a/tests/fixtures/examplePost.json
+++ b/tests/fixtures/examplePost.json
@@ -1,0 +1,14 @@
+{
+    "event": "Access Permitted",
+    "oper": "POST",
+    "usrName": "DevOpsServicesOrganization@us.ibm.com",
+    "req_body": {
+        "description": "null",
+        "generator": "tapeTest",
+        "key": "idsorg-testopenToolchain",
+        "name": "welcomeToTheBestOpenToolchainInTheWorldWideWeb",
+        "public": true,
+        "organization_guid": "my-org-guid"
+    } 
+
+}

--- a/tests/unit/testFixLength.js
+++ b/tests/unit/testFixLength.js
@@ -1,0 +1,48 @@
+/**
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2016. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ */
+ 'use strict';
+
+var test = require('tape'),
+    utilFunctions = require('../../utils/functions');
+
+var exampleResult = require('../fixtures/examplePost.json');
+
+test('Result length under length limit', function(t) {
+
+    var resultDeepCopy = JSON.parse(JSON.stringify(exampleResult));
+
+    var newResult = utilFunctions.fixLength(JSON.parse(JSON.stringify(resultDeepCopy)), 300);
+
+    t.equal(JSON.stringify(newResult), JSON.stringify(resultDeepCopy), 
+        'is the json object with length under the limit unchanged?');
+    t.end();
+});
+
+test('Result length over length limit by a key', function(t) {
+    var resultDeepCopy = JSON.parse(JSON.stringify(exampleResult));
+
+    var newResult = utilFunctions.fixLength(JSON.parse(JSON.stringify(resultDeepCopy)), 200);
+    delete resultDeepCopy.req_body;
+
+    t.equal(JSON.stringify(newResult), JSON.stringify(resultDeepCopy), 
+        'did the json object with length over the limit get the longest key-value removed?');
+    t.end();
+});
+
+test('Result length over length limit by two keys', function(t) {
+    var resultDeepCopy = JSON.parse(JSON.stringify(exampleResult));
+
+    var newResult = utilFunctions.fixLength(JSON.parse(JSON.stringify(resultDeepCopy)), 50);
+    delete resultDeepCopy.req_body;
+    delete resultDeepCopy.usrName;
+
+    t.equal(JSON.stringify(newResult), JSON.stringify(resultDeepCopy), 
+        'did the json object with length over the limit get the longest key-value removed?');
+    t.end();
+});

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -59,8 +59,7 @@ function getHostIP() {
         });
     });
     // get the IP from the first network interface we found that’s IPv4 and not internal
-    hostIP = addresses[Object.keys(addresses)[0]] || 'no external IPv4 network interface found';
-    return hostIP;
+    return addresses[Object.keys(addresses)[0]] || 'no external IPv4 network interface found';
 };
 
 function getEventName(statusCode) {

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -1,0 +1,82 @@
+/**
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2016. All Rights Reserved.
+ *
+ * Note to U.S. Government Users Restricted Rights:
+ * Use, duplication or disclosure restricted by GSA ADP Schedule
+ * Contract with IBM Corp.
+ */
+'use strict';
+
+var os = require('os');
+
+module.exports = {
+    fixLength: fixLength,
+    getHostIP: getHostIP,
+    getEventName: getEventName
+};
+
+function increasingLengthComparator(a, b) {
+    return a.keyObjectLength - b.keyObjectLength;
+};
+
+function fixLength(result, limit) {
+    var resultLengths = [];
+
+    for (var key in result) {
+        // each param will have its key, value, a space char, a colon and 
+        // comma separating values in the output log message.
+        var keyObjectLength = JSON.stringify(key).length + JSON.stringify(result[key]).length + 3;
+        var keyObject = {
+            'key': key,
+            'keyObjectLength': keyObjectLength
+        }
+        resultLengths.push(keyObject);
+    }
+
+    resultLengths.sort(increasingLengthComparator);
+
+    var currentTotalLength = JSON.stringify(result).length;
+
+    while (currentTotalLength > limit) {
+        var greatestKeyObject = resultLengths.pop();
+        delete result[greatestKeyObject.key];
+        currentTotalLength = JSON.stringify(result).length;
+    }
+
+    return result
+};
+
+function getHostIP() {
+    var interfaces = os.networkInterfaces();
+    var addresses = {};
+    Object.keys(interfaces).forEach(function(interfaceName) {
+        interfaces[interfaceName].forEach(function(itf) {
+            if (itf.internal || itf.family !== 'IPv4') {
+                return;
+            }
+            addresses[interfaceName] = itf.address; 
+        });
+    });
+    // get the IP from the first network interface we found that’s IPv4 and not internal
+    hostIP = addresses[Object.keys(addresses)[0]] || 'no external IPv4 network interface found';
+    return hostIP;
+};
+
+function getEventName(statusCode) {
+
+    if (!statusCode) {
+        return "Unknown";
+    }
+
+    if (statusCode >= 200 && statusCode < 300) {
+        return "Access Permitted";
+    }
+    else if (statusCode >=400 && statusCode < 500) {
+        return "Access Denied";
+    }
+    else {
+        return "Unknown";
+    }
+
+};


### PR DESCRIPTION
This addresses https://github.com/IBM/node-qradar-audit-logs-middleware/issues/5

QRadar has a hard limit on the length of messages to be less than 4096 chars, 1024 for UDP. We'll need to ensure that messages are smaller than that, in particular some messages with large bodies are going over and we have malformed/weird messages appearing in QRadar.
See http://www-01.ibm.com/support/docview.wss?uid=swg21622313 for more details

Assumptions: the qradar appender will add no more than 150 chars as headers of the message.

This leaves about 850 chars to use in the message itself for UDP messages, and about 3850 for TCP ones.

Algorithm will be as follows:
compute length of message to log.

if less than limit, log as normal
if greater than limit, sort by largest to smallest keys, keep deleting largest key until under limit. Then log.